### PR TITLE
Revoke default access to 1 vault to mitigate oddities with vault acce…

### DIFF
--- a/src/main/java/com/artillexstudios/axvaults/utils/PermissionUtils.java
+++ b/src/main/java/com/artillexstudios/axvaults/utils/PermissionUtils.java
@@ -12,7 +12,7 @@ public class PermissionUtils {
         if (CONFIG.getInt("permission-mode", 0) == 0) return player.hasPermission("axvaults.vault." + vault);
         if (player.isOp()) return true;
 
-        int max = player.hasPermission("axvaults.vault.1") ? 1 : 0;
+        int max = 0;
         for (PermissionAttachmentInfo effectivePermission : player.getEffectivePermissions()) {
             if (!effectivePermission.getValue()) continue;
             if (effectivePermission.getPermission().equals("*")) return true;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,8 +8,6 @@ softdepend:
   - PlaceholderAPI
 
 permissions:
-  axvaults.vault.1:
-    default: true
   axvaults.selector:
     default: true
   axvaults.openremote:


### PR DESCRIPTION
…ss when multiple permission contexts without contextual scopes are provided

This resolved my continual issue. If server owners wish for their players to have access to one vault, they can manually assign the node instead. This ensures that I no longer have to go out of my way to deny a particular/specific vault number, which in my opinion is also weird.