### PR TITLE
Fix MySQL going to insane sizes

### DIFF
--- a/src/main/java/com/artillexstudios/axvaults/database/impl/MySQL.java
+++ b/src/main/java/com/artillexstudios/axvaults/database/impl/MySQL.java
@@ -205,6 +205,8 @@ public class MySQL implements Database {
     }
 
     private void sendMessage(@NotNull ChangeType changeType, int id, UUID uuid) {
+        if (CONFIG.getString("multi-server-support", "sql").equalsIgnoreCase("none")) return;
+
         final String sql = "INSERT INTO axvaults_messages(event, vault_id, uuid, date) VALUES (?, ?, ?, ?);";
         try (Connection conn = dataSource.getConnection(); PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             stmt.setShort(1, (short) changeType.ordinal());


### PR DESCRIPTION
When using MySQL, on every call to saveVault method calls sendMessage method as well.
This leads to a few problems:
- sendMessage is called and it is saved no matter the multi-server-support state
- **BUT** removeOldChanges is not called when multi-server-support is set to false making the database huge overtime