### PR TITLE
Added whitelist and improved blacklist

### DIFF
--- a/src/main/java/com/artillexstudios/axvaults/AxVaults.java
+++ b/src/main/java/com/artillexstudios/axvaults/AxVaults.java
@@ -20,11 +20,7 @@ import com.artillexstudios.axvaults.database.impl.MySQL;
 import com.artillexstudios.axvaults.database.impl.SQLite;
 import com.artillexstudios.axvaults.database.messaging.SQLMessaging;
 import com.artillexstudios.axvaults.libraries.Libraries;
-import com.artillexstudios.axvaults.listeners.BlackListListener;
-import com.artillexstudios.axvaults.listeners.BlockBreakListener;
-import com.artillexstudios.axvaults.listeners.InventoryCloseListener;
-import com.artillexstudios.axvaults.listeners.PlayerInteractListener;
-import com.artillexstudios.axvaults.listeners.PlayerListeners;
+import com.artillexstudios.axvaults.listeners.*;
 import com.artillexstudios.axvaults.schedulers.AutoSaveScheduler;
 import com.artillexstudios.axvaults.utils.UpdateNotifier;
 import com.artillexstudios.axvaults.vaults.Vault;
@@ -92,6 +88,7 @@ public final class AxVaults extends AxPlugin {
 
         getServer().getPluginManager().registerEvents(new PlayerListeners(), this);
         getServer().getPluginManager().registerEvents(new BlackListListener(), this);
+        getServer().getPluginManager().registerEvents(new WhiteListListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerInteractListener(), this);
         getServer().getPluginManager().registerEvents(new BlockBreakListener(), this);
         getServer().getPluginManager().registerEvents(new InventoryCloseListener(), this);

--- a/src/main/java/com/artillexstudios/axvaults/guis/VaultSelector.java
+++ b/src/main/java/com/artillexstudios/axvaults/guis/VaultSelector.java
@@ -45,8 +45,8 @@ public class VaultSelector {
                 .disableAllInteractions()
                 .create();
 
-        List<Integer> slots = MESSAGES.getStringList("guis.selector.slots").stream()
-            .map(IntRange::parseIntRange)
+        List<Integer> slots = MESSAGES.getList("guis.selector.slots").stream()
+            .map(IntRange::valueOf)
             .flatMap((range) -> range.getValues().stream())
             .toList();
 
@@ -107,8 +107,8 @@ public class VaultSelector {
             Section itemSection = MESSAGES.getSection("gui-items." + s);
             final GuiItem item = new GuiItem(new ItemBuilder(itemSection).get());
 
-            gui.setItem(MESSAGES.getStringList("gui-items.%s.slots".formatted(s)).stream()
-                .map(IntRange::parseIntRange)
+            gui.setItem(MESSAGES.getList("gui-items.%s.slots".formatted(s)).stream()
+                .map(IntRange::valueOf)
                 .flatMap((range) -> range.getValues().stream())
                 .toList(), item);
         }

--- a/src/main/java/com/artillexstudios/axvaults/listeners/BlackListListener.java
+++ b/src/main/java/com/artillexstudios/axvaults/listeners/BlackListListener.java
@@ -1,5 +1,6 @@
 package com.artillexstudios.axvaults.listeners;
 
+import com.artillexstudios.axvaults.utils.IntRange;
 import com.artillexstudios.axvaults.vaults.Vault;
 import com.artillexstudios.axvaults.vaults.VaultManager;
 import org.bukkit.entity.Player;
@@ -35,6 +36,17 @@ public class BlackListListener implements Listener {
 
             if (CONFIG.getString("blacklisted-items." + s + ".material") != null) {
                 if (!it.getType().toString().equalsIgnoreCase(CONFIG.getString("blacklisted-items." + s + ".material"))) continue;
+                banned = true;
+            }
+
+            if (CONFIG.getString("blacklisted-items." + s + ".custom-model-data") != null) {
+                if (it.getItemMeta() == null
+                    || !it.getItemMeta().hasCustomModelData()
+                    || !IntRange.parseIntRange(CONFIG.getString("blacklisted-items." + s + ".custom-model-data")).contains(it.getItemMeta().getCustomModelData())
+                ) {
+                    continue;
+                }
+
                 banned = true;
             }
 

--- a/src/main/java/com/artillexstudios/axvaults/listeners/BlackListListener.java
+++ b/src/main/java/com/artillexstudios/axvaults/listeners/BlackListListener.java
@@ -42,7 +42,7 @@ public class BlackListListener implements Listener {
             if (CONFIG.getString("blacklisted-items." + s + ".custom-model-data") != null) {
                 if (it.getItemMeta() == null
                     || !it.getItemMeta().hasCustomModelData()
-                    || !IntRange.parseIntRange(CONFIG.getString("blacklisted-items." + s + ".custom-model-data")).contains(it.getItemMeta().getCustomModelData())
+                    || !IntRange.valueOf(CONFIG.get("blacklisted-items." + s + ".custom-model-data")).contains(it.getItemMeta().getCustomModelData())
                 ) {
                     continue;
                 }

--- a/src/main/java/com/artillexstudios/axvaults/listeners/WhiteListListener.java
+++ b/src/main/java/com/artillexstudios/axvaults/listeners/WhiteListListener.java
@@ -41,7 +41,7 @@ public class WhiteListListener implements Listener {
             if (CONFIG.getString("whitelisted-items." + s + ".custom-model-data") != null
                 && (it.getItemMeta() == null
                 || !it.getItemMeta().hasCustomModelData()
-                || !IntRange.parseIntRange(CONFIG.getString("whitelisted-items." + s + ".custom-model-data")).contains(it.getItemMeta().getCustomModelData()))
+                || !IntRange.valueOf(CONFIG.get("whitelisted-items." + s + ".custom-model-data")).contains(it.getItemMeta().getCustomModelData()))
             ) {
                 continue;
             }

--- a/src/main/java/com/artillexstudios/axvaults/listeners/WhiteListListener.java
+++ b/src/main/java/com/artillexstudios/axvaults/listeners/WhiteListListener.java
@@ -32,23 +32,24 @@ public class WhiteListListener implements Listener {
         final ItemStack it = event.getClick() == ClickType.NUMBER_KEY ? player.getInventory().getItem(event.getHotbarButton()) : event.getCurrentItem();
         if (it == null) return;
         for (String s : CONFIG.getSection("whitelisted-items").getRoutesAsStrings(false)) {
-            boolean banned = false;
-
-            if (CONFIG.getString("whitelisted-items." + s + ".material") != null) {
-                if (it.getType().toString().equalsIgnoreCase(CONFIG.getString("whitelisted-items." + s + ".material"))) continue;
-                banned = true;
+            if (CONFIG.getString("whitelisted-items." + s + ".material") != null
+                && !it.getType().toString().equalsIgnoreCase(CONFIG.getString("whitelisted-items." + s + ".material"))
+            ) {
+                continue;
             }
 
-            if (CONFIG.getString("whitelisted-items." + s + ".custom-model-data") != null) {
-                if (it.getItemMeta() != null && IntRange.parseIntRange(CONFIG.getString("whitelisted-items." + s + ".custom-model-data")).contains(it.getItemMeta().getCustomModelData())) continue;
-                banned = true;
+            if (CONFIG.getString("whitelisted-items." + s + ".custom-model-data") != null
+                && (it.getItemMeta() == null
+                || !it.getItemMeta().hasCustomModelData()
+                || !IntRange.parseIntRange(CONFIG.getString("whitelisted-items." + s + ".custom-model-data")).contains(it.getItemMeta().getCustomModelData()))
+            ) {
+                continue;
             }
 
-            if (banned) {
-                event.setCancelled(true);
-                MESSAGEUTILS.sendLang(player, "banned-item");
-                return;
-            }
+            return;
         }
+
+        event.setCancelled(true);
+        MESSAGEUTILS.sendLang(player, "banned-item");
     }
 }

--- a/src/main/java/com/artillexstudios/axvaults/listeners/WhiteListListener.java
+++ b/src/main/java/com/artillexstudios/axvaults/listeners/WhiteListListener.java
@@ -1,0 +1,54 @@
+package com.artillexstudios.axvaults.listeners;
+
+import com.artillexstudios.axvaults.utils.IntRange;
+import com.artillexstudios.axvaults.vaults.Vault;
+import com.artillexstudios.axvaults.vaults.VaultManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import static com.artillexstudios.axvaults.AxVaults.CONFIG;
+import static com.artillexstudios.axvaults.AxVaults.MESSAGEUTILS;
+
+public class WhiteListListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onClick(InventoryClickEvent event) {
+        if (CONFIG.getSection("whitelisted-items") == null) return;
+        boolean isVault = false;
+        for (Vault vault : VaultManager.getVaults()) {
+            if (vault.getStorage().equals(event.getView().getTopInventory())) {
+                isVault = true;
+                break;
+            }
+        }
+        if (!isVault) return;
+
+        final Player player = (Player) event.getWhoClicked();
+        final ItemStack it = event.getClick() == ClickType.NUMBER_KEY ? player.getInventory().getItem(event.getHotbarButton()) : event.getCurrentItem();
+        if (it == null) return;
+        for (String s : CONFIG.getSection("whitelisted-items").getRoutesAsStrings(false)) {
+            boolean banned = false;
+
+            if (CONFIG.getString("whitelisted-items." + s + ".material") != null) {
+                if (it.getType().toString().equalsIgnoreCase(CONFIG.getString("whitelisted-items." + s + ".material"))) continue;
+                banned = true;
+            }
+
+            if (CONFIG.getString("whitelisted-items." + s + ".custom-model-data") != null) {
+                if (it.getItemMeta() != null && IntRange.parseIntRange(CONFIG.getString("whitelisted-items." + s + ".custom-model-data")).contains(it.getItemMeta().getCustomModelData())) continue;
+                banned = true;
+            }
+
+            if (banned) {
+                event.setCancelled(true);
+                MESSAGEUTILS.sendLang(player, "banned-item");
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/artillexstudios/axvaults/utils/IntRange.java
+++ b/src/main/java/com/artillexstudios/axvaults/utils/IntRange.java
@@ -1,0 +1,98 @@
+package com.artillexstudios.axvaults.utils;
+
+import java.util.Random;
+
+public class IntRange implements Cloneable {
+    private static final Random RANDOM = new Random();
+
+    private final int min;
+    private final int max;
+
+    /**
+     * @param min Minimum value (inclusive)
+     * @param max Maximum value in range (inclusive)
+     */
+    public IntRange(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    /**
+     * @param value Minimum and maximum value (inclusive)
+     */
+    public IntRange(int value) {
+        this.min = value;
+        this.max = value;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+    public boolean contains(int number) {
+        return number >= min && number <= max;
+    }
+
+    /**
+     * @see IntRange#contains(int)
+     */
+    @Deprecated
+    public boolean inRange(int number) {
+        return contains(number);
+    }
+
+    public int next() {
+        if (min == max) {
+            return min;
+        }
+
+        return RANDOM.nextInt(min, max + 1);
+    }
+
+    public static IntRange parseIntRange(String string) throws NumberFormatException {
+        if (string == null) {
+            throw new NumberFormatException("Cannot parse null string");
+        }
+
+        String[] values = string.split("-");
+        switch (values.length) {
+            case 1 -> {
+                int value = Integer.parseInt(values[0]);
+                return new IntRange(value, value);
+            }
+            case 2 -> {
+                return new IntRange(Integer.parseInt(values[0]), Integer.parseInt(values[1]));
+            }
+            default -> throw new NumberFormatException("Cannot parse invalid range format");
+        }
+    }
+
+    public static IntRange valueOf(Object object) throws NumberFormatException {
+        String s;
+        try {
+            s = (String) object;
+        } catch (ClassCastException e) {
+            return new IntRange((int) object);
+        }
+
+        return parseIntRange(s);
+    }
+
+    @Override
+    public String toString() {
+        return min + "-" + max;
+    }
+
+    @Override
+    public IntRange clone() {
+        try {
+            return (IntRange) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
+    }
+}

--- a/src/main/java/com/artillexstudios/axvaults/utils/IntRange.java
+++ b/src/main/java/com/artillexstudios/axvaults/utils/IntRange.java
@@ -1,5 +1,7 @@
 package com.artillexstudios.axvaults.utils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 public class IntRange implements Cloneable {
@@ -31,6 +33,16 @@ public class IntRange implements Cloneable {
 
     public int getMax() {
         return max;
+    }
+
+    public List<Integer> getValues() {
+        List<Integer> list = new ArrayList<>();
+
+        for (int i = min; i <= max; i++) {
+            list.add(i);
+        }
+
+        return list;
     }
 
     public boolean contains(int number) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,6 +65,15 @@ max-vault-amount: -1
 # if enabled, the icon picker will not close after selecting an item
 selector-stay-open: false
 
+# list of items that CAN be put in vaults
+whitelisted-items:
+  "1":
+    material: "paper"
+    custom-model-data: 100-250
+  "2":
+    material: "paper"
+    custom-model-data: 300-700
+
 # list of items that CAN'T be put in vaults
 # note: the name-contains string shouldn't include any color codes
 blacklisted-items:


### PR DESCRIPTION
**Changelog:**
- Added whitelist to config to allow only a specific list of materials to be added *(Supports custom model data)*
  - The whitelist is parsed before the blacklist, if an item passes the whitelist it can still be blocked by the blacklist
- Added custom model data support to blacklist, `custom-model-data` accepts an integer or integer range, in the format `3-5` where the minimum is the first number and the maximum is the second number