### PR TITLE
Open vaults instead of ender chests

### DIFF
--- a/src/main/java/com/artillexstudios/axvaults/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/artillexstudios/axvaults/listeners/PlayerInteractListener.java
@@ -1,8 +1,10 @@
 package com.artillexstudios.axvaults.listeners;
 
 import com.artillexstudios.axvaults.commands.PlayerCommand;
+import com.artillexstudios.axvaults.guis.VaultSelector;
 import com.artillexstudios.axvaults.placed.PlacedVaults;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -10,6 +12,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
+
+import static com.artillexstudios.axvaults.AxVaults.CONFIG;
 
 public class PlayerInteractListener implements Listener {
 
@@ -19,15 +23,23 @@ public class PlayerInteractListener implements Listener {
         if (event.getClickedBlock() == null) return;
 
         final Player player = event.getPlayer();
+        if (event.getClickedBlock().getType() == Material.ENDER_CHEST && CONFIG.getBoolean("override-ender-chests")) {
+            event.setCancelled(true);
+            event.setUseInteractedBlock(Event.Result.DENY);
+            event.setUseItemInHand(Event.Result.DENY);
+
+            new VaultSelector().open(player);
+            return;
+        }
+
         final Location location = event.getClickedBlock().getLocation();
+        if (PlacedVaults.getVaults().containsKey(location)) {
+            event.setCancelled(true);
+            event.setUseInteractedBlock(Event.Result.DENY);
+            event.setUseItemInHand(Event.Result.DENY);
 
-        if (!PlacedVaults.getVaults().containsKey(location)) return;
-
-        event.setCancelled(true);
-        event.setUseInteractedBlock(Event.Result.DENY);
-        event.setUseItemInHand(Event.Result.DENY);
-
-        final Integer vault = PlacedVaults.getVaults().get(location);
-        new PlayerCommand().open(player, vault, true);
+            final Integer vault = PlacedVaults.getVaults().get(location);
+            new PlayerCommand().open(player, vault, true);
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -46,6 +46,9 @@ max-vault-amount: -1
 # if enabled, the icon picker will not close after selecting an item
 selector-stay-open: false
 
+# open vaults menu instead when opening an ender chest
+override-ender-chests: false
+
 # list of items that CAN'T be sold in the auction house
 #
 # supported regex: (optional)


### PR DESCRIPTION
Added a config option to override ender chests and open vaults instead. By default, i set it to false and server admins can enable it if they want to use vaults instead of standard ender chests on their server.